### PR TITLE
Add dynamic checksum for node exporter

### DIFF
--- a/ansible/roles/fabric_server/tasks/main.yml
+++ b/ansible/roles/fabric_server/tasks/main.yml
@@ -18,9 +18,9 @@
     name: "Asia/Seoul"
 
 # 3️⃣ Fabric installer download -------------------------------------------
-- name: Download Fabric installer {{ fabric_installer_ver }} (as minecraft)
+- name: Download Fabric installer {{ fabric_installer_version }} (as minecraft)
   get_url:
-    url: https://maven.fabricmc.net/net/fabricmc/fabric-installer/{{ fabric_installer_ver }}/fabric-installer-{{ fabric_installer_ver }}.jar
+    url: https://maven.fabricmc.net/net/fabricmc/fabric-installer/{{ fabric_installer_version }}/fabric-installer-{{ fabric_installer_version }}.jar
     dest: /opt/minecraft/fabric-installer.jar
     mode: "0755"
     checksum: "sha256:38aa82ab1ef829b7aa3f2143fcc93bba706a8e18835be731d0fdf231d274b07f"

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -6,17 +6,27 @@
     shell: /usr/sbin/nologin
     system: yes
 
-- name: Download node_exporter 1.9.1 tar.gz
+- name: Download node_exporter checksum file
+  uri:
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
+    return_content: yes
+  register: node_exporter_checksum_file
+
+- name: Parse node_exporter checksum
+  set_fact:
+    node_exporter_checksum: "{{ (node_exporter_checksum_file.content.splitlines() | select('search', 'node_exporter-' ~ node_exporter_version ~ '.linux-amd64.tar.gz') | list | first).split()[0] }}"
+
+- name: Download node_exporter {{ node_exporter_version }} tar.gz
   get_url:
-    url: https://github.com/prometheus/node_exporter/releases/download/v1.9.1/node_exporter-1.9.1.linux-amd64.tar.gz
-    dest: /tmp/node_exporter-1.9.1.tar.gz
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+    dest: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
     mode: "0644"
-    checksum: "sha256:becb950ee80daa8ae7331d77966d94a611af79ad0d3307380907e0ec08f5b4e8"   # ✔ 무결성 검증
+    checksum: "sha256:{{ node_exporter_checksum }}"   # ✔ 무결성 검증
   register: dl_node
 
 - name: Unpack binary
   unarchive:
-    src: /tmp/node_exporter-1.9.1.tar.gz
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
     dest: /usr/local/bin/
     remote_src: yes
     creates: /usr/local/bin/node_exporter

--- a/ansible/vars/versions.yml
+++ b/ansible/vars/versions.yml
@@ -1,3 +1,4 @@
 fabric_installer_ver: "1.0.3"
 afabric_mc_version: "1.21.5"   # ✏️  Minecraft 서버 버전
 afabric_loader_version: "0.16.14"  # ✏️  Fabric Loader 버전
+node_exporter_version: "1.9.1"

--- a/ansible/vars/versions.yml
+++ b/ansible/vars/versions.yml
@@ -1,4 +1,4 @@
-fabric_installer_ver: "1.0.3"
+fabric_installer_version: "1.0.3"
 afabric_mc_version: "1.21.5"   # ✏️  Minecraft 서버 버전
 afabric_loader_version: "0.16.14"  # ✏️  Fabric Loader 버전
 node_exporter_version: "1.9.1"


### PR DESCRIPTION
## Summary
- fetch node_exporter checksum from GitHub
- parse checksum and validate download
- expose `node_exporter_version` variable

## Testing
- `ansible-playbook --syntax-check ansible/site.yml`
- `ansible-lint ansible/site.yml` *(fails: name casing, FQCN, yaml formatting)*

------
https://chatgpt.com/codex/tasks/task_e_686a647e63c88324b1beb5fa806e902b