### PR TITLE
feat: implement configurable memory for Fabric server

### DIFF
--- a/ansible/roles/fabric_server/defaults/main.yml
+++ b/ansible/roles/fabric_server/defaults/main.yml
@@ -1,2 +1,0 @@
-server_xms: "6G"
-server_xmx: "6G"

--- a/ansible/roles/fabric_server/defaults/main.yml
+++ b/ansible/roles/fabric_server/defaults/main.yml
@@ -1,0 +1,2 @@
+server_xms: "6G"
+server_xmx: "6G"

--- a/ansible/roles/fabric_server/tasks/main.yml
+++ b/ansible/roles/fabric_server/tasks/main.yml
@@ -100,7 +100,7 @@
       [Service]
       User=minecraft
       WorkingDirectory=/opt/minecraft
-      ExecStart=/usr/bin/java -Xms6G -Xmx6G \
+      ExecStart=/usr/bin/java -Xms{{ server_xms }} -Xmx{{ server_xmx }} \
         -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 \
         -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch \
         -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M \

--- a/ansible/vars/server_properties.yml
+++ b/ansible/vars/server_properties.yml
@@ -1,5 +1,9 @@
-server_xms: "6G"
-server_xmx: "6G"
+# # This file contains variables for the Minecraft server properties and configurations.
+
+# server_xms and server_xmx should be set to same value for optimal performance.
+# The values should be specified in gigabytes (G) or megabytes (M).
+server_xms: "6G"  # Minimum memory allocation for the Minecraft server
+server_xmx: "6G"  # Maximum memory allocation for the Minecraft server
 
 minecraft_server_properties:
   motd: "\u00a7c(\uacbd)\u00a7a Sinchon\u00a72 Server\u00a7e \uc7ac\u00a76\uac1c\u00a7e\uc7a5\u00a7c (\ucd95)\u00a7r\n\u00a77\uc6b4\uc601 \uae30\uac04: \u00a7f~25.09.29"

--- a/ansible/vars/server_properties.yml
+++ b/ansible/vars/server_properties.yml
@@ -1,3 +1,6 @@
+server_xms: "6G"
+server_xmx: "6G"
+
 minecraft_server_properties:
   motd: "\u00a7c(\uacbd)\u00a7a Sinchon\u00a72 Server\u00a7e \uc7ac\u00a76\uac1c\u00a7e\uc7a5\u00a7c (\ucd95)\u00a7r\n\u00a77\uc6b4\uc601 \uae30\uac04: \u00a7f~25.09.29"
   max-players: "10"

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@
 
 ## 4. 추가 정보
 - 모드 목록과 서버 속성은 `ansible/vars` 하위 파일에서 관리합니다.
+- 서버 메모리 크기는 `ansible/roles/fabric_server/defaults/main.yml`의
+  `server_xms`, `server_xmx` 변수로 조정할 수 있습니다.
 - 자세한 과정은 [Notion 문서](https://www.notion.so/MC-2241afe72e6980da8b2ac86e0bcf270e)를 참고하실 수 있습니다.
 
 

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,7 @@
 
 ## 4. 추가 정보
 - 모드 목록과 서버 속성은 `ansible/vars` 하위 파일에서 관리합니다.
-- 서버 메모리 크기는 `ansible/roles/fabric_server/defaults/main.yml`의
-  `server_xms`, `server_xmx` 변수로 조정할 수 있습니다.
+- 서버 메모리 크기는 `ansible/roles/fabric_server/defaults/main.yml`의 `server_xms`, `server_xmx` 변수로 조정할 수 있습니다.
 - 자세한 과정은 [Notion 문서](https://www.notion.so/MC-2241afe72e6980da8b2ac86e0bcf270e)를 참고하실 수 있습니다.
 
 


### PR DESCRIPTION
## Summary
- allow customizing Fabric server memory via variables
- use new vars in Fabric service unit
- document how to change the memory size

## Testing
- `ansible-lint ansible/roles/fabric_server/tasks/main.yml`
- `ansible-playbook ansible/site.yml --syntax-check` *(fails: couldn't resolve module 'community.general.timezone')*
- `ansible-playbook ansible/status.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6868cef94a58832499d23fbae105ba77