### PR TITLE
feat(ansible): add mod_config playbook

### DIFF
--- a/ansible/mod_config.yml
+++ b/ansible/mod_config.yml
@@ -1,0 +1,155 @@
+- name: Manage mod configuration repository
+  hosts: minecraft
+  become: true
+  vars_files:
+    - vars/mods_sync.yml
+  tasks:
+    - name: Ensure config directory exists
+      ansible.builtin.file:
+        path: /opt/minecraft/config
+        state: directory
+        owner: minecraft
+        group: minecraft
+        mode: "0755"
+
+    - name: Ensure .ssh directory exists
+      ansible.builtin.file:
+        path: /home/minecraft/.ssh
+        state: directory
+        owner: minecraft
+        group: minecraft
+        mode: "0700"
+
+    - name: Extract repo host
+      ansible.builtin.set_fact:
+        config_repo_host: "{{ config_repo.split('@')[-1].split(':')[0] }}"
+
+    - name: Add repository host to known_hosts
+      ansible.builtin.known_hosts:
+        path: /home/minecraft/.ssh/known_hosts
+        name: "{{ config_repo_host }}"
+        key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + config_repo_host) }}"
+        state: present
+        hash_host: false
+
+    - name: Check if deploy key exists
+      ansible.builtin.stat:
+        path: /home/minecraft/.ssh/id_rsa_mod_config.pub
+      register: mod_key_stat
+
+    - name: Generate deploy key
+      community.crypto.openssh_keypair:
+        path: /home/minecraft/.ssh/id_rsa_mod_config
+        type: rsa
+        size: 4096
+        owner: minecraft
+        group: minecraft
+        mode: "0600"
+      when: not mod_key_stat.stat.exists
+      register: mod_deploy_key
+
+    - name: Show deploy key instructions
+      ansible.builtin.debug:
+        msg: |
+          A new SSH deploy key has been generated for the config repository.
+          Add /home/minecraft/.ssh/id_rsa_mod_config.pub to your repository.
+      when: mod_deploy_key.changed or not mod_key_stat.stat.exists
+
+    - name: Check if config repo initialized
+      ansible.builtin.stat:
+        path: /opt/minecraft/config/.git
+      register: config_repo_stat
+      become: true
+      become_user: minecraft
+
+    - name: Initialize config git repo
+      ansible.builtin.command: git init -b {{ config_repo_branch }}
+      args:
+        chdir: /opt/minecraft/config
+        creates: /opt/minecraft/config/.git
+        warn: false
+      become: true
+      become_user: minecraft
+      when: not config_repo_stat.stat.exists
+      register: config_init
+
+    - name: Set git user.name
+      community.general.git_config:
+        name: user.name
+        value: "{{ config_git_user_name }}"
+        scope: local
+        repo: /opt/minecraft/config
+      become: true
+      become_user: minecraft
+
+    - name: Set git user.email
+      community.general.git_config:
+        name: user.email
+        value: "{{ config_git_user_email }}"
+        scope: local
+        repo: /opt/minecraft/config
+      become: true
+      become_user: minecraft
+
+    - name: Add origin remote
+      ansible.builtin.command: git remote add origin {{ config_repo }}
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      when: config_init.changed
+      become: true
+      become_user: minecraft
+
+    - name: Initial commit
+      ansible.builtin.command: git add .
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      when: config_init.changed
+      become: true
+      become_user: minecraft
+
+    - name: Commit initial content
+      ansible.builtin.command: git commit -m "Initial config" || true
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      when: config_init.changed
+      changed_when: false
+      become: true
+      become_user: minecraft
+
+    - name: Push initial repository
+      ansible.builtin.command: git push -u origin {{ config_repo_branch }}
+      environment:
+        GIT_SSH_COMMAND: "ssh -i /home/minecraft/.ssh/id_rsa_mod_config -o StrictHostKeyChecking=no"
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      when: config_init.changed
+      changed_when: false
+      become: true
+      become_user: minecraft
+
+    - name: Pull latest config
+      ansible.builtin.command: git pull --rebase
+      environment:
+        GIT_SSH_COMMAND: "ssh -i /home/minecraft/.ssh/id_rsa_mod_config -o StrictHostKeyChecking=no"
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      changed_when: false
+      become: true
+      become_user: minecraft
+
+    - name: Push local changes
+      ansible.builtin.command: git push origin {{ config_repo_branch }}
+      environment:
+        GIT_SSH_COMMAND: "ssh -i /home/minecraft/.ssh/id_rsa_mod_config -o StrictHostKeyChecking=no"
+      args:
+        chdir: /opt/minecraft/config
+        warn: false
+      when: config_push_changes | bool
+      changed_when: false
+      become: true
+      become_user: minecraft

--- a/ansible/vars/mods_sync.yml
+++ b/ansible/vars/mods_sync.yml
@@ -1,0 +1,10 @@
+# Mod configuration repository settings
+config_repo: "git@github.com:example/mc-config.git"
+config_repo_branch: "main"
+
+# Git user for commits
+config_git_user_name: "Minecraft Config Bot"
+config_git_user_email: "minecraft-config@example.com"
+
+# Whether to push local config changes back to remote
+config_push_changes: false

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,14 @@
    ```
    상태 확인만 하려면 다음을 실행합니다.
    ```bash
-   ansible-playbook -i inventory.ini status.yml
-   ```
-   인벤토리 파일에는 대상 서버의 IP와 SSH 정보가 들어 있습니다.
+ansible-playbook -i inventory.ini status.yml
+```
+인벤토리 파일에는 대상 서버의 IP와 SSH 정보가 들어 있습니다.
+
+모드 설정 파일만 동기화하려면 다음을 실행합니다.
+```bash
+ansible-playbook -i inventory.ini mod_config.yml
+```
 
 ## 4. 모드 관리 스크립트
 `scripts/manage_mods.py`는 [Modrinth](https://modrinth.com) API를 이용해 모드 정보를 조회하고 `ansible/vars/mods.yml`을 자동으로 갱신합니다.


### PR DESCRIPTION
## Summary
- add `mod_config.yml` playbook for syncing `/opt/minecraft/config`
- allow configuration of repo details in `vars/mods_sync.yml`
- document playbook usage in the README

## Testing
- `ansible-lint ansible/mod_config.yml` *(fails: command-instead-of-module, inline-env-var, no-changed-when, no-handler)*

------
https://chatgpt.com/codex/tasks/task_e_68761773fa8c8324b948c35f4ca8f879